### PR TITLE
fix: ntp/systemd-timesyncd having unmet dependencies on aarch64

### DIFF
--- a/pkg/controller/operatingsystemconfig/scripts/installNTP.sh
+++ b/pkg/controller/operatingsystemconfig/scripts/installNTP.sh
@@ -12,7 +12,7 @@ install_ntp() {
   # We mitigate this by uninstalling systemd-timesyncd first
   # so there is no conflict anymore.
   if [[ $(uname -m) == "aarch64" ]]; then
-    apt remove systemd-timesyncd
+    apt remove -y systemd-timesyncd
   fi
   echo "apt update && apt install -y ntp"
   apt update && DEBIAN_FRONTEND=noninteractive apt install -o Dpkg::Options::="--force-confold" -y ntp
@@ -37,7 +37,7 @@ install_systemd_timesyncd() {
   # We mitigate this by uninstalling ntp first
   # so there is no conflict anymore.
   if [[ $(uname -m) == "aarch64" ]]; then
-    apt remove ntp
+    apt remove -y ntp
   fi
   echo "apt update && apt install -y systemd-timesyncd"
   apt update && DEBIAN_FRONTEND=noninteractive apt install -y systemd-timesyncd

--- a/pkg/controller/operatingsystemconfig/scripts/installNTP.sh
+++ b/pkg/controller/operatingsystemconfig/scripts/installNTP.sh
@@ -8,6 +8,12 @@ install_ntp() {
     echo "Package is already installed!"
     return
   fi
+  # Package seems to be broken on aarch64 for Ubuntu 22.04
+  # We mitigate this by uninstalling systemd-timesyncd first
+  # so there is no conflict anymore.
+  if [[ $(uname -m) == "aarch64" ]]; then
+    apt remove systemd-timesyncd
+  fi
   echo "apt update && apt install -y ntp"
   apt update && DEBIAN_FRONTEND=noninteractive apt install -o Dpkg::Options::="--force-confold" -y ntp
   echo "ntp installed successfully!"
@@ -26,6 +32,12 @@ install_systemd_timesyncd() {
   if package_installed systemd-timesyncd; then
     echo "Package is already installed!"
     return
+  fi
+  # Package seems to be broken on aarch64 for Ubuntu 22.04
+  # We mitigate this by uninstalling ntp first
+  # so there is no conflict anymore.
+  if [[ $(uname -m) == "aarch64" ]]; then
+    apt remove ntp
   fi
   echo "apt update && apt install -y systemd-timesyncd"
   apt update && DEBIAN_FRONTEND=noninteractive apt install -y systemd-timesyncd


### PR DESCRIPTION
**How to categorize this PR?**
/area os
/kind bug
/os ubuntu

**What this PR does / why we need it**:

Fixxes this
```
Mar 11 10:30:54 shoot--ske-ci--e2e-1he7kuv-pool3-z1-5988b-jndrw bash[17901]: Some packages could not be installed. This may mean that you have
Mar 11 10:30:54 shoot--ske-ci--e2e-1he7kuv-pool3-z1-5988b-jndrw bash[17901]: requested an impossible situation or if you are using the unstable
Mar 11 10:30:54 shoot--ske-ci--e2e-1he7kuv-pool3-z1-5988b-jndrw bash[17901]: distribution that some required packages have not yet been created
Mar 11 10:30:54 shoot--ske-ci--e2e-1he7kuv-pool3-z1-5988b-jndrw bash[17901]: or been moved out of Incoming.
Mar 11 10:30:54 shoot--ske-ci--e2e-1he7kuv-pool3-z1-5988b-jndrw bash[17901]: The following information may help to resolve the situation:
Mar 11 10:30:54 shoot--ske-ci--e2e-1he7kuv-pool3-z1-5988b-jndrw bash[17901]: The following packages have unmet dependencies:
Mar 11 10:30:54 shoot--ske-ci--e2e-1he7kuv-pool3-z1-5988b-jndrw bash[17901]:  ntpsec : Conflicts: time-daemon
Mar 11 10:30:54 shoot--ske-ci--e2e-1he7kuv-pool3-z1-5988b-jndrw bash[17901]:  systemd-timesyncd : Conflicts: time-daemon
Mar 11 10:30:54 shoot--ske-ci--e2e-1he7kuv-pool3-z1-5988b-jndrw bash[17901]: E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
Mar 11 10:30:54 shoot--ske-ci--e2e-1he7kuv-pool3-z1-5988b-jndrw systemd[1]: install-ntp-client.service: Main process exited, code=exited, status=100/n/a
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
