### PR TITLE
Block jammy-updates for containerd instead of pin version

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -108,7 +108,14 @@ EOF
 chmod 0644 /etc/cloud/cloud.cfg.d/custom-networking.cfg
 ` + writeFilesToDiskScript + `
 ` + writeUnitsToDiskScript + `
-until apt-get update -qq && apt-get install --no-upgrade -qqy containerd=1.7.24-0ubuntu1~22.04.2 runc socat nfs-common logrotate jq policykit-1; do sleep 1; done
+
+cat <<EOF > /etc/apt/preferences.d/99-containerd-block-jammy-updates
+Package: containerd
+Pin: release a=jammy-updates
+Pin-Priority: -10
+EOF
+
+until apt-get update -qq && apt-get install --no-upgrade -qqy containerd runc socat nfs-common logrotate jq policykit-1; do sleep 1; done
 
 if [ ! -s /etc/containerd/config.toml ]; then
   mkdir -p /etc/containerd/


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test|dependency-update
-->
/area os
/kind bug
/os ubuntu

/hold

**What this PR does / why we need it**:

Instead of pin the version to `1.7.24-0ubuntu1~22.04.2` we can lower the prio for `jammy-updates` to always install the version from `jammy-security`.

**Special notes for your reviewer**:


