### PR TITLE
Block jammy-updates for containerd instead of pin version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 /bin
 hack/tools/bin
 
+artifacts/
+images.txt
+images.json
+
 *.coverprofile
 *.html
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,14 @@ GARDENER_HACK_DIR           := $(shell go list -m -f "{{.Dir}}" github.com/garde
 EXTENSION_PREFIX            := gardener-extension
 NAME                        := os-ubuntu
 REGISTRY                    := europe-docker.pkg.dev/gardener-project/public
-IMAGE_PREFIX                := $(REGISTRY)/gardener/extensions
+IMAGE_PREFIX                := $(REGISTRY)/stackitcloud/gardener-extension-os-ubuntu
 REPO_ROOT                   := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 HACK_DIR                    := $(REPO_ROOT)/hack
-VERSION 					:= $(shell git describe --tags --exact-match 2>/dev/null || git rev-parse --short=7 HEAD)
+VERSION 					:= $(shell git describe --tag --always --dirty)
 LD_FLAGS                    := "-w -X github.com/gardener/$(EXTENSION_PREFIX)-$(NAME)/pkg/version.Version=$(IMAGE_TAG)"
 LEADER_ELECTION             := true
 IGNORE_OPERATION_ANNOTATION := true
 PLATFORM                    ?= linux/amd64
-
-export REPO                 := reg3.infra.ske.eu01.stackit.cloud/stackitcloud/gardener-extension-os-ubuntu
-export TAG                  := $(VERSION)
 
 #########################################
 # Tools                                 #
@@ -53,10 +50,10 @@ OUTPUT_IMAGES_PATH = "images.txt"
 
 .PHONY: images
 images: $(KO) ## Builds a container image with the app using ko. Use PUSH=True to also push the image to a registry
-	KO_DOCKER_REPO=$(REPO) \
+	KO_DOCKER_REPO="$(IMAGE_PREFIX)" \
 	$(KO) build --push=$(PUSH) \
 	--image-label org.opencontainers.image.source="https://github.com/stackitcloud/gardener-extension-os-ubuntu" \
-	--sbom none -t $(TAG) --bare \
+	--sbom none -t $(VERSION) --bare \
 	--platform linux/amd64,linux/arm64 \
 	./cmd/$(EXTENSION_PREFIX)-$(NAME) \
 	| tee $(OUTPUT_IMAGES_PATH)

--- a/Makefile
+++ b/Makefile
@@ -10,17 +10,26 @@ REGISTRY                    := europe-docker.pkg.dev/gardener-project/public
 IMAGE_PREFIX                := $(REGISTRY)/gardener/extensions
 REPO_ROOT                   := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 HACK_DIR                    := $(REPO_ROOT)/hack
-VERSION                     := $(shell cat "$(REPO_ROOT)/VERSION")
+VERSION 					:= $(shell git describe --tags --exact-match 2>/dev/null || git rev-parse --short=7 HEAD)
 LD_FLAGS                    := "-w -X github.com/gardener/$(EXTENSION_PREFIX)-$(NAME)/pkg/version.Version=$(IMAGE_TAG)"
 LEADER_ELECTION             := true
 IGNORE_OPERATION_ANNOTATION := true
 PLATFORM                    ?= linux/amd64
 
+export REPO                 := reg3.infra.ske.eu01.stackit.cloud/stackitcloud/gardener-extension-os-ubuntu
+export TAG                  := $(VERSION)
+
 #########################################
 # Tools                                 #
 #########################################
 
-TOOLS_DIR := $(HACK_DIR)/tools
+TOOLS_DIR := $(HACK_DIR)/tools/bin
+
+KO := $(TOOLS_DIR)/ko
+KO_VERSION ?= v0.18.1
+$(KO): $(call tool_version_file,$(KO),$(KO_VERSION))
+	GOBIN=$(abspath $(TOOLS_DIR)) go install github.com/google/ko@$(KO_VERSION)
+
 include $(GARDENER_HACK_DIR)/tools.mk
 
 #########################################
@@ -38,6 +47,27 @@ start:
 #################################################################
 # Rules related to binary build, Docker image build and release #
 #################################################################
+
+PUSH ?= false
+OUTPUT_IMAGES_PATH = "images.txt"
+
+.PHONY: images
+images: $(KO) ## Builds a container image with the app using ko. Use PUSH=True to also push the image to a registry
+	KO_DOCKER_REPO=$(REPO) \
+	$(KO) build --push=$(PUSH) \
+	--image-label org.opencontainers.image.source="https://github.com/stackitcloud/gardener-extension-os-ubuntu" \
+	--sbom none -t $(TAG) --bare \
+	--platform linux/amd64,linux/arm64 \
+	./cmd/$(EXTENSION_PREFIX)-$(NAME) \
+	| tee $(OUTPUT_IMAGES_PATH)
+	@jq -n --arg key "$(EXTENSION_PREFIX)-$(NAME)" --arg value "$$(cat $(OUTPUT_IMAGES_PATH))" '{images: {($$key): $$value}}' > images.json
+
+.PHONY: artifacts-only
+artifacts-only: $(YQ) $(HELM) ## Builds helm charts (`charts/`)
+	PUSH=$(PUSH) hack/push-artifacts.sh images.json
+
+.PHONY: artifacts
+artifacts: images artifacts-only ## Builds all artifacts.
 
 .PHONY: install
 install:

--- a/charts/gardener-extension-os-ubuntu/templates/deployment.yaml
+++ b/charts/gardener-extension-os-ubuntu/templates/deployment.yaml
@@ -35,8 +35,7 @@ spec:
       - name: gardener-extension-os-ubuntu
         image: {{ include "image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command:
-        - /gardener-extension-os-ubuntu
+        args:
         - --max-concurrent-reconciles={{ .Values.controllers.concurrentSyncs }}
         - --disable-controllers={{ .Values.disableControllers | join "," }}
         - --heartbeat-namespace={{ .Release.Namespace }} 

--- a/hack/push-artifacts.sh
+++ b/hack/push-artifacts.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+images=$(cat "$1")
+chart_names="gardener-extension-os-ubuntu"
+helm_artifacts=artifacts/charts
+
+rm -rf "$helm_artifacts"
+mkdir -p "$helm_artifacts"
+
+function oci_repo() {
+    local chart_name="$1"
+    local image_full_tag=$(echo "$images" | jq -r ".images.\"${chart_name}\"")
+    echo "$image_full_tag" | rev | cut -d'/' -f2- | rev
+}
+
+function image_repo() {
+    local chart_name="$1"
+    local image_full_tag=$(echo "$images" | jq -r ".images.\"${chart_name}\"")
+    echo "$image_full_tag" | cut -d ':' -f 1
+}
+
+function image_tag() {
+    local chart_name="$1"
+    local image_full_tag=$(echo "$images" | jq -r ".images.\"${chart_name}\"")
+    echo "$(image_tag_with_digest $chart_name)" | cut -d'@' -f1 | sed 's/-dirty//'
+}
+
+function image_tag_with_digest() {
+    local chart_name="$1"
+    local image_full_tag=$(echo "$images" | jq -r ".images.\"${chart_name}\"")
+    echo "$image_full_tag" | cut -d ':' -f 2-
+}
+
+function package_and_push_chart() {
+    # Always delete the previous, since in the case of subcharts the build_dir is the same!
+    rm -rf "${helm_artifacts}/${chart_name}"
+    chart_build_dir="${helm_artifacts}/${chart_name}"
+    mkdir -p "$chart_build_dir"
+
+    local chart_source_dir="$1"
+    cp -r "${chart_source_dir}/." "$chart_build_dir"
+
+    yq -i "\
+      ( .image.repository = \"$(image_repo ${chart_name})\" ) | \
+      ( .image.tag = \"$(image_tag_with_digest ${chart_name})\" )\
+    " "$chart_build_dir/values.yaml"
+
+    helm_package_raw_output=$(helm package "$chart_build_dir" --version "$(image_tag ${chart_name})" -d "$helm_artifacts" 2>&1)
+
+    if [ $? -ne 0 ]; then
+        echo "Error: helm package failed for chart ${chart_name}."
+        echo "$helm_package_raw_output"
+        exit 1
+    fi
+
+    packaged_chart_file=$(echo "$helm_package_raw_output" | tail -n 1 | sed -n 's/Successfully packaged chart \(into: \|and saved it to: \)\(.*\)/\2/p')
+
+    if [ -z "$packaged_chart_file" ] || [ ! -f "$packaged_chart_file" ]; then
+        echo "Error: 'helm package' claimed success but did not output a valid packaged chart path or the file does not exist for ${chart_name}."
+        echo "$helm_package_raw_output"
+        exit 1
+    fi
+
+    # TODO: If this error (i.e. Unauthorized) then nothing is printed
+    push_output=$(helm push "$packaged_chart_file" "oci://$(oci_repo ${chart_name})/charts" 2>&1)
+
+    pushed_line=$(echo "$push_output" | grep "Pushed:")
+    digest_line=$(echo "$push_output" | grep "Digest:")
+
+    if [ -n "$pushed_line" ] && [ -n "$digest_line" ]; then
+        echo "$pushed_line"
+        echo "$digest_line"
+    else
+        echo "Error: Failed to push chart ${chart_name}."
+        echo "$push_output"
+        exit 1
+    fi
+}
+
+if [ "$PUSH" != "true" ]; then
+    echo "Skip pushing artifacts because PUSH is not set to 'true'"
+    exit 0
+fi
+
+for chart_name in $chart_names; do
+    chart_source_dir="charts/${chart_name}"
+
+    if [ -d "${chart_source_dir}/charts" ]; then
+        echo "$chart_name has multiple charts"
+        for subchart in "${chart_source_dir}"/charts/*; do
+            echo "${chart_source_dir}/charts/${subchart}"
+            package_and_push_chart "${chart_source_dir}/charts/${subchart}"
+        done
+    else
+        package_and_push_chart "${chart_source_dir}"
+    fi
+
+done

--- a/hack/push-artifacts.sh
+++ b/hack/push-artifacts.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -o errexit
 set -o nounset
 set -o pipefail
 
@@ -91,7 +90,7 @@ for chart_name in $chart_names; do
 
     if [ -d "${chart_source_dir}/charts" ]; then
         echo "$chart_name has multiple charts"
-        for subchart in "${chart_source_dir}"/charts/*; do
+        for subchart in $(ls "${chart_source_dir}/charts"); do
             echo "${chart_source_dir}/charts/${subchart}"
             package_and_push_chart "${chart_source_dir}/charts/${subchart}"
         done

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -108,7 +108,14 @@ EOF
 chmod 0644 /etc/cloud/cloud.cfg.d/custom-networking.cfg
 ` + writeFilesToDiskScript + `
 ` + writeUnitsToDiskScript + `
-until apt-get update -qq && apt-get install --no-upgrade -qqy containerd=1.7.24-0ubuntu1~22.04.2 runc socat nfs-common logrotate jq policykit-1; do sleep 1; done
+
+cat <<EOF > /etc/apt/preferences.d/99-containerd-block-jammy-updates
+Package: containerd
+Pin: release a=jammy-updates
+Pin-Priority: -10
+EOF
+
+until apt-get update -qq && apt-get install --no-upgrade -qqy containerd runc socat nfs-common logrotate jq policykit-1; do sleep 1; done
 
 if [ ! -s /etc/containerd/config.toml ]; then
   mkdir -p /etc/containerd/


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test|dependency-update
-->
/kind bug
/os ubuntu

/hold

**What this PR does / why we need it**:

Instead of pin the version to `1.7.24-0ubuntu1~22.04.2` we can lower the prio for `jammy-updates` to always install the version from `jammy-security`.

**Special notes for your reviewer**:


