### PR TITLE
Fix multiple interfaces in ntpd config

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -374,7 +374,9 @@ restrict [::1]
 
 interface ignore wildcard
 interface listen 127.0.0.1
-interface listen dev1 dev2`,
+interface listen dev1
+interface listen dev2
+`,
 						},
 					},
 				}))

--- a/pkg/controller/operatingsystemconfig/templates/ntp-config.conf.tpl
+++ b/pkg/controller/operatingsystemconfig/templates/ntp-config.conf.tpl
@@ -10,5 +10,7 @@ restrict [::1]
 {{ if .Interfaces -}}
 interface ignore wildcard
 interface listen 127.0.0.1
-interface listen {{ .Interfaces | join " " }}
+{{ range .Interfaces -}}
+interface listen {{ . }}
+{{ end -}}
 {{- end }}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test|dependency-update
-->
/area os
/kind bug
/os ubuntu

/cc @stackitcloud/ske-infrastructure 

**What this PR does / why we need it**:
The ntpd config needs to have a line per inteface and not multiple interfaces at one line. Only the first Interface was used by ntpd.
After rolling this out I also will PR this to upstream os-ubuntu and os-coreos.


