### PR TITLE
Use pinned containerd.io from docker apt mirror

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -109,19 +109,14 @@ chmod 0644 /etc/cloud/cloud.cfg.d/custom-networking.cfg
 ` + writeFilesToDiskScript + `
 ` + writeUnitsToDiskScript + `
 
-cat <<EOF > /etc/apt/preferences.d/99-containerd-block-jammy-updates
-Package: containerd
-Pin: release a=jammy-updates
-Pin-Priority: -10
-EOF
+curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] http://mirror.eu01.stackit.cloud/docker jammy stable" > /etc/apt/sources.list.d/stackit-docker-mirror.list
 
-until apt-get update -qq && apt-get install --no-upgrade -qqy containerd runc socat nfs-common logrotate jq policykit-1; do sleep 1; done
+until apt-get update -qq && apt-get install --no-upgrade -qqy containerd.io=1.7.29-1~ubuntu.22.04~jammy socat nfs-common logrotate jq policykit-1; do sleep 1; done
+apt-mark hold containerd.io
 
-if [ ! -s /etc/containerd/config.toml ]; then
-  mkdir -p /etc/containerd/
-  containerd config default > /etc/containerd/config.toml
-  chmod 0644 /etc/containerd/config.toml
-fi
+containerd config default > /etc/containerd/config.toml
+chmod 0644 /etc/containerd/config.toml
 
 mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF > /etc/systemd/system/containerd.service.d/11-exec_config.conf

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -85,13 +85,15 @@ var _ = Describe("Actuator", func() {
     cat << EOF | base64 -d > "/etc/systemd/system/some-unit"
     Zm9v
     EOF
-    until apt-get update -qq && apt-get install --no-upgrade -qqy containerd runc socat nfs-common logrotate jq policykit-1; do sleep 1; done
 
-    if [ ! -s /etc/containerd/config.toml ]; then
-      mkdir -p /etc/containerd/
-      containerd config default > /etc/containerd/config.toml
-      chmod 0644 /etc/containerd/config.toml
-    fi
+    curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] http://mirror.eu01.stackit.cloud/docker jammy stable" > /etc/apt/sources.list.d/stackit-docker-mirror.list
+
+    until apt-get update -qq && apt-get install --no-upgrade -qqy containerd.io=1.7.29-1~ubuntu.22.04~jammy socat nfs-common logrotate jq policykit-1; do sleep 1; done
+    apt-mark hold containerd.io
+
+    containerd config default > /etc/containerd/config.toml
+    chmod 0644 /etc/containerd/config.toml
 
     mkdir -p /etc/systemd/system/containerd.service.d
     cat <<EOF > /etc/systemd/system/containerd.service.d/11-exec_config.conf
@@ -149,13 +151,15 @@ var _ = Describe("Actuator", func() {
     cat << EOF | base64 -d > "/etc/systemd/system/some-unit"
     Zm9v
     EOF
-    until apt-get update -qq && apt-get install --no-upgrade -qqy containerd runc socat nfs-common logrotate jq policykit-1; do sleep 1; done
 
-    if [ ! -s /etc/containerd/config.toml ]; then
-      mkdir -p /etc/containerd/
-      containerd config default > /etc/containerd/config.toml
-      chmod 0644 /etc/containerd/config.toml
-    fi
+    curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] http://mirror.eu01.stackit.cloud/docker jammy stable" > /etc/apt/sources.list.d/stackit-docker-mirror.list
+
+    until apt-get update -qq && apt-get install --no-upgrade -qqy containerd.io=1.7.29-1~ubuntu.22.04~jammy socat nfs-common logrotate jq policykit-1; do sleep 1; done
+    apt-mark hold containerd.io
+
+    containerd config default > /etc/containerd/config.toml
+    chmod 0644 /etc/containerd/config.toml
 
     mkdir -p /etc/systemd/system/containerd.service.d
     cat <<EOF > /etc/systemd/system/containerd.service.d/11-exec_config.conf
@@ -219,13 +223,15 @@ var _ = Describe("Actuator", func() {
     cat << EOF | base64 -d > "/etc/systemd/system/some-unit"
     Zm9v
     EOF
-    until apt-get update -qq && apt-get install --no-upgrade -qqy containerd runc socat nfs-common logrotate jq policykit-1; do sleep 1; done
 
-    if [ ! -s /etc/containerd/config.toml ]; then
-      mkdir -p /etc/containerd/
-      containerd config default > /etc/containerd/config.toml
-      chmod 0644 /etc/containerd/config.toml
-    fi
+    curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] http://mirror.eu01.stackit.cloud/docker jammy stable" > /etc/apt/sources.list.d/stackit-docker-mirror.list
+
+    until apt-get update -qq && apt-get install --no-upgrade -qqy containerd.io=1.7.29-1~ubuntu.22.04~jammy socat nfs-common logrotate jq policykit-1; do sleep 1; done
+    apt-mark hold containerd.io
+
+    containerd config default > /etc/containerd/config.toml
+    chmod 0644 /etc/containerd/config.toml
 
     mkdir -p /etc/systemd/system/containerd.service.d
     cat <<EOF > /etc/systemd/system/containerd.service.d/11-exec_config.conf


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test|dependency-update
-->
/kind enhancement
/os ubuntu

**What this PR does / why we need it**:

This PR adds the docker APT repository from our eu01 mirror (incl. the needed sining keys).

Then we install `containerd.io` from the docker APT repository instead of `containerd` from the Ubuntu APT repository. in the docker APT repository are multiple versions, so we can pin the wanted version. 

With that PR we pin `1.7.29-1~ubuntu.22.04~jammy` as `containerd.io` version.

Additionally we always recreate the `containerd` config, as the default from the docker APT repository is not working with gardener.
