### PR TITLE
Improve ubuntu init script with `sha256` check

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -109,8 +109,20 @@ chmod 0644 /etc/cloud/cloud.cfg.d/custom-networking.cfg
 ` + writeFilesToDiskScript + `
 ` + writeUnitsToDiskScript + `
 
-curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] http://mirror.eu01.stackit.cloud/docker jammy stable" > /etc/apt/sources.list.d/stackit-docker-mirror.list
+GPG_KEYPRINT="9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88"
+curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg -o docker.gpg
+
+if gpg --show-keys --fingerprint docker.gpg | grep -q "$GPG_KEYPRINT"; then
+	echo "OK"
+else
+	echo "GPG Integrity check failed"
+	exit 1
+fi
+
+gpg --dearmor -o /etc/apt/keyrings/docker.gpg docker.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] http://mirror.eu01.stackit.cloud/docker jammy stable" \
+	> /etc/apt/sources.list.d/stackit-docker-mirror.list
 
 until apt-get update -qq && apt-get install --no-upgrade -qqy containerd.io=1.7.29-1~ubuntu.22.04~jammy socat nfs-common logrotate jq policykit-1; do sleep 1; done
 apt-mark hold containerd.io

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -109,14 +109,14 @@ chmod 0644 /etc/cloud/cloud.cfg.d/custom-networking.cfg
 ` + writeFilesToDiskScript + `
 ` + writeUnitsToDiskScript + `
 
-SHA_256="1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570 docker.gpg"
-curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg -o docker.gpg
+SHA_256="1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570 /tmp/docker.gpg"
+curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg -o /tmp/docker.gpg
 echo "$SHA_256" | sha256sum -c - || {
     echo "GPG Integrity check failed"
     exit 1
 }
 
-gpg --dearmor -o /etc/apt/keyrings/docker.gpg docker.gpg
+gpg --dearmor -o /etc/apt/keyrings/docker.gpg /tmp/docker.gpg
 echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] http://mirror.eu01.stackit.cloud/docker jammy stable" \
     > /etc/apt/sources.list.d/stackit-docker-mirror.list
 

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -111,16 +111,11 @@ chmod 0644 /etc/cloud/cloud.cfg.d/custom-networking.cfg
 
 GPG_KEYPRINT="9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88"
 curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg -o docker.gpg
-
-if gpg --show-keys --fingerprint docker.gpg | grep -q "$GPG_KEYPRINT"; then
-	echo "OK"
-else
+gpg --show-keys --fingerprint docker.gpg | grep -q "$GPG_KEYPRINT" || {
 	echo "GPG Integrity check failed"
 	exit 1
-fi
-
+}
 gpg --dearmor -o /etc/apt/keyrings/docker.gpg docker.gpg
-
 echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] http://mirror.eu01.stackit.cloud/docker jammy stable" \
 	> /etc/apt/sources.list.d/stackit-docker-mirror.list
 

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -109,9 +109,9 @@ chmod 0644 /etc/cloud/cloud.cfg.d/custom-networking.cfg
 ` + writeFilesToDiskScript + `
 ` + writeUnitsToDiskScript + `
 
-GPG_KEYPRINT="9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88"
+SHA_256="1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570 docker.gpg"
 curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg -o docker.gpg
-gpg --show-keys --fingerprint docker.gpg | grep -q "$GPG_KEYPRINT" || {
+echo "$SHA_256" | sha256sum -c - || {
 	echo "GPG Integrity check failed"
 	exit 1
 }

--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -112,12 +112,13 @@ chmod 0644 /etc/cloud/cloud.cfg.d/custom-networking.cfg
 SHA_256="1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570 docker.gpg"
 curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg -o docker.gpg
 echo "$SHA_256" | sha256sum -c - || {
-	echo "GPG Integrity check failed"
-	exit 1
+    echo "GPG Integrity check failed"
+    exit 1
 }
+
 gpg --dearmor -o /etc/apt/keyrings/docker.gpg docker.gpg
 echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] http://mirror.eu01.stackit.cloud/docker jammy stable" \
-	> /etc/apt/sources.list.d/stackit-docker-mirror.list
+    > /etc/apt/sources.list.d/stackit-docker-mirror.list
 
 until apt-get update -qq && apt-get install --no-upgrade -qqy containerd.io=1.7.29-1~ubuntu.22.04~jammy socat nfs-common logrotate jq policykit-1; do sleep 1; done
 apt-mark hold containerd.io

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -86,8 +86,16 @@ var _ = Describe("Actuator", func() {
     Zm9v
     EOF
 
-    curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-    echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] http://mirror.eu01.stackit.cloud/docker jammy stable" > /etc/apt/sources.list.d/stackit-docker-mirror.list
+    SHA_256="1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570 docker.gpg"
+    curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg -o docker.gpg
+    echo "$SHA_256" | sha256sum -c - || {
+        echo "GPG Integrity check failed"
+        exit 1
+    }
+
+    gpg --dearmor -o /etc/apt/keyrings/docker.gpg docker.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] http://mirror.eu01.stackit.cloud/docker jammy stable" \
+        > /etc/apt/sources.list.d/stackit-docker-mirror.list
 
     until apt-get update -qq && apt-get install --no-upgrade -qqy containerd.io=1.7.29-1~ubuntu.22.04~jammy socat nfs-common logrotate jq policykit-1; do sleep 1; done
     apt-mark hold containerd.io
@@ -152,8 +160,16 @@ var _ = Describe("Actuator", func() {
     Zm9v
     EOF
 
-    curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-    echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] http://mirror.eu01.stackit.cloud/docker jammy stable" > /etc/apt/sources.list.d/stackit-docker-mirror.list
+    SHA_256="1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570 docker.gpg"
+    curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg -o docker.gpg
+    echo "$SHA_256" | sha256sum -c - || {
+        echo "GPG Integrity check failed"
+        exit 1
+    }
+
+    gpg --dearmor -o /etc/apt/keyrings/docker.gpg docker.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] http://mirror.eu01.stackit.cloud/docker jammy stable" \
+        > /etc/apt/sources.list.d/stackit-docker-mirror.list
 
     until apt-get update -qq && apt-get install --no-upgrade -qqy containerd.io=1.7.29-1~ubuntu.22.04~jammy socat nfs-common logrotate jq policykit-1; do sleep 1; done
     apt-mark hold containerd.io
@@ -224,8 +240,16 @@ var _ = Describe("Actuator", func() {
     Zm9v
     EOF
 
-    curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-    echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] http://mirror.eu01.stackit.cloud/docker jammy stable" > /etc/apt/sources.list.d/stackit-docker-mirror.list
+    SHA_256="1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570 docker.gpg"
+    curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg -o docker.gpg
+    echo "$SHA_256" | sha256sum -c - || {
+        echo "GPG Integrity check failed"
+        exit 1
+    }
+
+    gpg --dearmor -o /etc/apt/keyrings/docker.gpg docker.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] http://mirror.eu01.stackit.cloud/docker jammy stable" \
+        > /etc/apt/sources.list.d/stackit-docker-mirror.list
 
     until apt-get update -qq && apt-get install --no-upgrade -qqy containerd.io=1.7.29-1~ubuntu.22.04~jammy socat nfs-common logrotate jq policykit-1; do sleep 1; done
     apt-mark hold containerd.io

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -86,14 +86,14 @@ var _ = Describe("Actuator", func() {
     Zm9v
     EOF
 
-    SHA_256="1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570 docker.gpg"
-    curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg -o docker.gpg
+    SHA_256="1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570 /tmp/docker.gpg"
+    curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg -o /tmp/docker.gpg
     echo "$SHA_256" | sha256sum -c - || {
         echo "GPG Integrity check failed"
         exit 1
     }
 
-    gpg --dearmor -o /etc/apt/keyrings/docker.gpg docker.gpg
+    gpg --dearmor -o /etc/apt/keyrings/docker.gpg /tmp/docker.gpg
     echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] http://mirror.eu01.stackit.cloud/docker jammy stable" \
         > /etc/apt/sources.list.d/stackit-docker-mirror.list
 
@@ -160,14 +160,14 @@ var _ = Describe("Actuator", func() {
     Zm9v
     EOF
 
-    SHA_256="1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570 docker.gpg"
-    curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg -o docker.gpg
+    SHA_256="1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570 /tmp/docker.gpg"
+    curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg -o /tmp/docker.gpg
     echo "$SHA_256" | sha256sum -c - || {
         echo "GPG Integrity check failed"
         exit 1
     }
 
-    gpg --dearmor -o /etc/apt/keyrings/docker.gpg docker.gpg
+    gpg --dearmor -o /etc/apt/keyrings/docker.gpg /tmp/docker.gpg
     echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] http://mirror.eu01.stackit.cloud/docker jammy stable" \
         > /etc/apt/sources.list.d/stackit-docker-mirror.list
 
@@ -240,14 +240,14 @@ var _ = Describe("Actuator", func() {
     Zm9v
     EOF
 
-    SHA_256="1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570 docker.gpg"
-    curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg -o docker.gpg
+    SHA_256="1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570 /tmp/docker.gpg"
+    curl -fsSL http://mirror.eu01.stackit.cloud/docker/gpg -o /tmp/docker.gpg
     echo "$SHA_256" | sha256sum -c - || {
         echo "GPG Integrity check failed"
         exit 1
     }
 
-    gpg --dearmor -o /etc/apt/keyrings/docker.gpg docker.gpg
+    gpg --dearmor -o /etc/apt/keyrings/docker.gpg /tmp/docker.gpg
     echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] http://mirror.eu01.stackit.cloud/docker jammy stable" \
         > /etc/apt/sources.list.d/stackit-docker-mirror.list
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test|dependency-update
-->
/kind enhancement
/os ubuntu

**What this PR does / why we need it**:

PR is seperated into single commits, to review them independent:

- Retrival of GPG key via `http` is insecure, should get it from the trusted source, to verify repository signatures.

**TODOs**
- [x] @dergeberl Discuss how to handle this
  - May use `go:embed` to embed the key? 
- [ ] Adapt the e2e test


